### PR TITLE
Add starter Node backend API for spots, catalog, and orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,30 @@ BroCode Spot is a full-stack web application designed to streamline group orderi
    npm run dev
    ```
 
+### Optional: Run the local backend API
+
+This project now includes a lightweight Node.js backend in `backend/server.js` that provides starter APIs for:
+- health check
+- login (mock)
+- catalog retrieval
+- spot listing
+- order creation/listing
+- bill summary
+
+Start it with:
+
+```bash
+npm run backend
+```
+
+Run frontend + backend together:
+
+```bash
+npm run dev:all
+```
+
+By default, the backend runs on `http://localhost:4000`.
+
 6. **Open in browser**
    ```
    http://localhost:5173

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,35 @@
+# Backend API (Starter)
+
+A minimal Node.js backend for BroCode Spot.
+
+## Start
+
+```bash
+npm run backend
+```
+
+Server starts at `http://localhost:4000` by default.
+
+## Available endpoints
+
+- `GET /api/health`
+- `POST /api/auth/login`
+- `GET /api/catalog`
+- `GET /api/catalog/:category` (`drinks`, `food`, `cigarettes`)
+- `GET /api/spots`
+- `GET /api/orders?spotId=...&userId=...`
+- `POST /api/orders`
+- `GET /api/bills/:spotId`
+
+## Example login payload
+
+```json
+{
+  "username": "brocode",
+  "password": "changeme"
+}
+```
+
+## Note
+
+Data is currently in-memory and resets whenever the process restarts. See `backend/store.js`.

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,185 @@
+import { createServer } from 'node:http';
+import { randomUUID } from 'node:crypto';
+import { URL } from 'node:url';
+import { dataStore } from './store.js';
+
+const port = Number(process.env.PORT || 4000);
+
+const sendJson = (res, statusCode, body) => {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  });
+  res.end(JSON.stringify(body));
+};
+
+const readBody = (req) =>
+  new Promise((resolve, reject) => {
+    let data = '';
+
+    req.on('data', (chunk) => {
+      data += chunk;
+    });
+
+    req.on('end', () => {
+      if (!data) {
+        resolve({});
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(data));
+      } catch {
+        reject(new Error('Invalid JSON payload'));
+      }
+    });
+
+    req.on('error', reject);
+  });
+
+const server = createServer(async (req, res) => {
+  const method = req.method || 'GET';
+  const parsedUrl = new URL(req.url || '/', `http://localhost:${port}`);
+  const path = parsedUrl.pathname;
+
+  if (method === 'OPTIONS') {
+    sendJson(res, 204, {});
+    return;
+  }
+
+  if (method === 'GET' && path === '/api/health') {
+    sendJson(res, 200, { status: 'ok', service: 'brocode-backend', timestamp: new Date().toISOString() });
+    return;
+  }
+
+  if (method === 'POST' && path === '/api/auth/login') {
+    try {
+      const { username, password } = await readBody(req);
+
+      if (!username || !password) {
+        sendJson(res, 400, { error: 'username and password are required' });
+        return;
+      }
+
+      const user = dataStore.users.find((item) => item.username === username && item.password === password);
+
+      if (!user) {
+        sendJson(res, 401, { error: 'invalid credentials' });
+        return;
+      }
+
+      const { password: _password, ...publicUser } = user;
+      sendJson(res, 200, { token: `demo-token-${user.id}`, user: publicUser });
+      return;
+    } catch (error) {
+      sendJson(res, 400, { error: error.message });
+      return;
+    }
+  }
+
+  if (method === 'GET' && path === '/api/catalog') {
+    sendJson(res, 200, dataStore.catalog);
+    return;
+  }
+
+  if (method === 'GET' && path.startsWith('/api/catalog/')) {
+    const category = path.replace('/api/catalog/', '');
+    const items = dataStore.catalog[category];
+
+    if (!items) {
+      sendJson(res, 404, { error: `Unknown category: ${category}` });
+      return;
+    }
+
+    sendJson(res, 200, items);
+    return;
+  }
+
+  if (method === 'GET' && path === '/api/spots') {
+    sendJson(res, 200, dataStore.spots);
+    return;
+  }
+
+  if (method === 'GET' && path === '/api/orders') {
+    const spotId = parsedUrl.searchParams.get('spotId');
+    const userId = parsedUrl.searchParams.get('userId');
+
+    const filteredOrders = dataStore.orders.filter((order) => {
+      if (spotId && order.spotId !== spotId) return false;
+      if (userId && order.userId !== userId) return false;
+      return true;
+    });
+
+    sendJson(res, 200, filteredOrders);
+    return;
+  }
+
+  if (method === 'POST' && path === '/api/orders') {
+    try {
+      const { spotId, userId, items } = await readBody(req);
+
+      if (!spotId || !userId || !Array.isArray(items) || items.length === 0) {
+        sendJson(res, 400, { error: 'spotId, userId and at least one order item are required' });
+        return;
+      }
+
+      const parsedItems = items.map((item) => {
+        const quantity = Number(item.quantity || 0);
+        const unitPrice = Number(item.unitPrice || 0);
+
+        return {
+          productId: item.productId,
+          name: item.name,
+          quantity,
+          unitPrice,
+          total: quantity * unitPrice,
+        };
+      });
+
+      const totalAmount = parsedItems.reduce((sum, item) => sum + item.total, 0);
+      const newOrder = {
+        id: randomUUID(),
+        spotId,
+        userId,
+        items: parsedItems,
+        totalAmount,
+        createdAt: new Date().toISOString(),
+      };
+
+      dataStore.orders.push(newOrder);
+      sendJson(res, 201, newOrder);
+      return;
+    } catch (error) {
+      sendJson(res, 400, { error: error.message });
+      return;
+    }
+  }
+
+  if (method === 'GET' && path.startsWith('/api/bills/')) {
+    const spotId = path.replace('/api/bills/', '');
+    const orders = dataStore.orders.filter((order) => order.spotId === spotId);
+
+    const userTotals = orders.reduce((acc, order) => {
+      acc[order.userId] = (acc[order.userId] || 0) + order.totalAmount;
+      return acc;
+    }, {});
+
+    const total = orders.reduce((sum, order) => sum + order.totalAmount, 0);
+
+    sendJson(res, 200, {
+      spotId,
+      total,
+      userTotals,
+      orderCount: orders.length,
+    });
+    return;
+  }
+
+  sendJson(res, 404, { error: 'Route not found' });
+});
+
+server.listen(port, () => {
+  console.log(`Backend API running on http://localhost:${port}`);
+});

--- a/backend/store.js
+++ b/backend/store.js
@@ -1,0 +1,58 @@
+export const dataStore = {
+  users: [
+    {
+      id: 'u-1',
+      username: 'brocode',
+      password: 'changeme',
+      name: 'Ram',
+      role: 'admin',
+    },
+    {
+      id: 'u-2',
+      username: 'dhanush',
+      password: 'changeme',
+      name: 'Dhanush',
+      role: 'user',
+    },
+  ],
+  spots: [
+    {
+      id: 'spot-2025-07-26',
+      location: 'Attibele Toll Plaza',
+      date: '2025-07-26T10:00:00.000Z',
+      hostUserId: 'u-1',
+    },
+  ],
+  catalog: {
+    drinks: [
+      { id: 'd-1', name: 'Brocode Beer', price: 180 },
+      { id: 'd-2', name: 'Kingfisher Beer', price: 170 },
+    ],
+    food: [
+      { id: 'f-1', name: 'Beef Biriyani', price: 220 },
+      { id: 'f-2', name: 'Parotta', price: 30 },
+    ],
+    cigarettes: [
+      { id: 'c-1', name: 'Marlboro', price: 25 },
+      { id: 'c-2', name: 'Classic', price: 20 },
+    ],
+  },
+  orders: [
+    {
+      id: 'ord-1',
+      spotId: 'spot-2025-07-26',
+      userId: 'u-2',
+      items: [
+        {
+          productId: 'd-1',
+          name: 'Brocode Beer',
+          quantity: 2,
+          unitPrice: 180,
+          total: 360,
+        },
+      ],
+      totalAmount: 360,
+      createdAt: '2025-07-26T10:30:00.000Z',
+    },
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "backend": "node backend/server.js",
+    "dev:all": "npm run backend & npm run dev"
   },
   "dependencies": {
     "@google/genai": "^0.3.0",


### PR DESCRIPTION
### Motivation
- Provide a lightweight local backend so the frontend can be developed and tested without an external Supabase instance.
- Offer a simple in-memory API surface for health, auth, catalog, spots, orders and bill summaries to speed up contributor onboarding.

### Description
- Added a minimal HTTP server at `backend/server.js` implementing endpoints for `/api/health`, `/api/auth/login`, `/api/catalog`, `/api/catalog/:category`, `/api/spots`, `/api/orders`, and `/api/bills/:spotId` with CORS and JSON body parsing.
- Added an in-memory seed data store at `backend/store.js` containing users, catalog items, a spot, and an initial order.
- Created `backend/README.md` with usage and endpoint documentation and updated the main `README.md` with instructions to run the backend and combined dev script.
- Added npm scripts `backend` and `dev:all` to run the backend alone or frontend+backend together.

### Testing
- Started the backend with `node backend/server.js` and the process ran successfully.
- Verified endpoints with `curl` calls to `/api/health`, `/api/catalog/drinks`, and a `POST /api/orders`, all returning expected JSON responses.
- Ran `npm run build` which failed due to existing unresolved merge conflict markers in `pages/PaymentPage.tsx`, an unrelated pre-existing issue not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ed86830483228639db96581142ee)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fuzziecoder/brocode-party-update-app/pull/16" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
