### PR TITLE
feat: add GET /api/orders/:id endpoint

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -109,6 +109,28 @@ const server = createServer(async (req, res) => {
     sendJson(res, 200, orders);
     return;
   }
+  if (method === 'GET' && path.startsWith('/api/orders/')) {
+    console.log("I AM INSIDE ORDER ID ROUTE");
+  const orderId = path.replace('/api/orders/', '');
+
+ 
+  const authHeader = req.headers.authorization;
+  if (!authHeader) {
+    sendJson(res, 401, { error: 'Unauthorized' });
+    return;
+  }
+
+  const orders = database.getOrders({});
+  const order = orders.find(o => o.id === orderId);
+
+  if (!order) {
+    sendJson(res, 404, { error: `Order not found: ${orderId}` });
+    return;
+  }
+
+  sendJson(res, 200, order);
+  return;
+}
 
   if (method === 'POST' && path === '/api/orders') {
     try {


### PR DESCRIPTION
Added a new GET /api/orders/:id endpoint to retrieve a single order by ID.

✔ Returns 200 with order payload when ID exists  
✔ Returns 404 when order not found  
✔ Returns 401 when Authorization header missing  

Tested locally and verified responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new order lookup functionality that enables users to retrieve specific orders by their unique identifier. The endpoint requires authentication and includes proper error handling for unauthorized requests, invalid credentials, and non-existent orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->