### PR TITLE
backend: add login rate limiting to mitigate brute-force attempts

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -24,6 +24,16 @@ Server starts at `http://localhost:4000` by default.
 - Passwords are stored as salted `scrypt` hashes (not plaintext).
 - Legacy plaintext user passwords are auto-migrated to hashed values on successful login.
 
+### Issue #29: Protect login endpoint from brute-force attempts
+
+- Login is now rate-limited per `IP + username` key.
+- Defaults: 5 failed attempts within 15 minutes triggers a 15 minute temporary block (`429`).
+- Configure via env vars:
+  - `LOGIN_RATE_LIMIT_MAX_ATTEMPTS`
+  - `LOGIN_RATE_LIMIT_WINDOW_MS`
+  - `LOGIN_RATE_LIMIT_BLOCK_MS`
+
+
 ## Available endpoints
 
 - `GET /api/health`

--- a/backend/server.js
+++ b/backend/server.js
@@ -4,6 +4,60 @@ import { database, dbPath } from './db.js';
 
 const port = Number(process.env.PORT || 4000);
 
+const LOGIN_RATE_LIMIT_MAX_ATTEMPTS = Number(process.env.LOGIN_RATE_LIMIT_MAX_ATTEMPTS || 5);
+const LOGIN_RATE_LIMIT_WINDOW_MS = Number(process.env.LOGIN_RATE_LIMIT_WINDOW_MS || 15 * 60 * 1000);
+const LOGIN_RATE_LIMIT_BLOCK_MS = Number(process.env.LOGIN_RATE_LIMIT_BLOCK_MS || 15 * 60 * 1000);
+const loginAttempts = new Map();
+
+const getLoginKey = (req, username) => {
+  const forwardedFor = req.headers['x-forwarded-for'];
+  const firstForwardedIp = Array.isArray(forwardedFor)
+    ? forwardedFor[0]
+    : typeof forwardedFor === 'string'
+      ? forwardedFor.split(',')[0]
+      : '';
+  const remoteIp = firstForwardedIp?.trim() || req.socket?.remoteAddress || 'unknown-ip';
+  return `${remoteIp}:${username}`;
+};
+
+const getRateLimitState = (key) => {
+  const now = Date.now();
+  const existing = loginAttempts.get(key);
+
+  if (!existing) {
+    const state = { count: 0, windowStart: now, blockedUntil: 0 };
+    loginAttempts.set(key, state);
+    return state;
+  }
+
+  if (existing.blockedUntil > 0 && existing.blockedUntil <= now) {
+    existing.count = 0;
+    existing.windowStart = now;
+    existing.blockedUntil = 0;
+  }
+
+  if (now - existing.windowStart > LOGIN_RATE_LIMIT_WINDOW_MS) {
+    existing.count = 0;
+    existing.windowStart = now;
+  }
+
+  return existing;
+};
+
+const clearRateLimitState = (key) => {
+  loginAttempts.delete(key);
+};
+
+const recordFailedLoginAttempt = (key) => {
+  const now = Date.now();
+  const state = getRateLimitState(key);
+  state.count += 1;
+
+  if (state.count >= LOGIN_RATE_LIMIT_MAX_ATTEMPTS) {
+    state.blockedUntil = now + LOGIN_RATE_LIMIT_BLOCK_MS;
+  }
+};
+
 const sendJson = (res, statusCode, body) => {
   res.writeHead(statusCode, {
     'Content-Type': 'application/json',
@@ -62,12 +116,27 @@ const server = createServer(async (req, res) => {
         return;
       }
 
+      const loginKey = getLoginKey(req, username);
+      const rateLimitState = getRateLimitState(loginKey);
+      const now = Date.now();
+      if (rateLimitState.blockedUntil > now) {
+        const retryAfterSeconds = Math.ceil((rateLimitState.blockedUntil - now) / 1000);
+        sendJson(res, 429, {
+          error: 'Too many failed login attempts. Please try again later.',
+          retryAfterSeconds,
+        });
+        return;
+      }
+
       const user = database.getUserByCredentials(username, password);
 
       if (!user) {
+        recordFailedLoginAttempt(loginKey);
         sendJson(res, 401, { error: 'invalid credentials' });
         return;
       }
+
+      clearRateLimitState(loginKey);
 
       sendJson(res, 200, { token: `demo-token-${user.id}`, user });
       return;


### PR DESCRIPTION
### Motivation

- Prevent brute-force attacks against the `POST /api/auth/login` endpoint by limiting repeated failed attempts. 
- Provide a simple, configurable protection layer that can be tuned via environment variables. 

### Description

- Added an in-memory rate limiter to `backend/server.js` that tracks failed attempts keyed by `IP + username` and stores `{count, windowStart, blockedUntil}` in a `Map`.
- The login key looks at `x-forwarded-for` and falls back to `req.socket.remoteAddress` to derive the client IP, and the limiter returns HTTP `429` with `retryAfterSeconds` when blocked.
- Failed attempts are recorded and, once the threshold is reached, the key is temporarily blocked; the rate-limit state is cleared after a successful authentication.
- Documented the change and configuration options in `backend/README.md`, with environment variables `LOGIN_RATE_LIMIT_MAX_ATTEMPTS`, `LOGIN_RATE_LIMIT_WINDOW_MS`, and `LOGIN_RATE_LIMIT_BLOCK_MS`.

### Testing

- Ran `node --check backend/server.js` and `node --check backend/db.js`, and both checks succeeded.
- Attempted automated runtime validation (starting the server and exercising the login endpoint), but server startup failed in this environment because Node.js does not support the `node:sqlite` builtin here, so integration requests could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b045592d8832eabdf6fd08613587b)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fuzziecoder/brocode-party-update-app/pull/37" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added login rate-limiting: failed login attempts are tracked per IP address and username. Reaching the threshold (default: 5 attempts within 15 minutes) triggers a 15-minute block returning HTTP 429. Behavior is configurable through environment variables.

* **Documentation**
  * Updated documentation with login rate-limiting configuration and behavior details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->