### PR TITLE
Add org-code multi-management scoping and fix notification fan-out

### DIFF
--- a/pages/DrinksPage.tsx
+++ b/pages/DrinksPage.tsx
@@ -126,7 +126,7 @@ const DrinksPage: React.FC = () => {
 
     try {
       setPageError(null);
-      const spotData = await spotService.getUpcomingSpot();
+      const spotData = await spotService.getUpcomingSpot(profile?.org_code);
       setSpot(spotData);
 
       if (spotData) {

--- a/pages/DrinksPageNew.tsx
+++ b/pages/DrinksPageNew.tsx
@@ -79,7 +79,7 @@ const DrinksPage: React.FC = () => {
     if (!profile) return;
 
     try {
-      const spotData = await spotService.getUpcomingSpot();
+      const spotData = await spotService.getUpcomingSpot(profile?.org_code);
       setSpot(spotData);
 
       if (spotData) {

--- a/pages/PaymentPage.tsx
+++ b/pages/PaymentPage.tsx
@@ -37,7 +37,7 @@ const PaymentPage: React.FC = () => {
 
   const fetchData = useCallback(async () => {
     try {
-      const spotData = await spotService.getUpcomingSpot();
+      const spotData = await spotService.getUpcomingSpot(profile?.org_code);
       setSpot(spotData);
 
       if (spotData) {

--- a/services/mockApi.ts
+++ b/services/mockApi.ts
@@ -46,6 +46,8 @@ let USERS_DB: Record<string, UserProfile> = {
     location: "Attibele",
     profile_pic_url: DEFAULT_AVATARS[0],
     isVerified: true,
+    org_code: '0001',
+    management_name: 'Brocode HQ',
   },
   dhanush: {
     id: "dhanush",
@@ -57,6 +59,8 @@ let USERS_DB: Record<string, UserProfile> = {
     location: "Attibele",
     profile_pic_url: DEFAULT_AVATARS[1],
     isVerified: true,
+    org_code: '0001',
+    management_name: 'Brocode HQ',
   },
   godwin: {
     id: "godwin",
@@ -68,6 +72,8 @@ let USERS_DB: Record<string, UserProfile> = {
     location: "Attibele",
     profile_pic_url: DEFAULT_AVATARS[2],
     isVerified: true,
+    org_code: '0001',
+    management_name: 'Brocode HQ',
   },
   tharun: {
     id: "tharun",
@@ -79,6 +85,8 @@ let USERS_DB: Record<string, UserProfile> = {
     location: "Attibele",
     profile_pic_url: DEFAULT_AVATARS[3],
     isVerified: true,
+    org_code: '0001',
+    management_name: 'Brocode HQ',
   },
   sanjay: {
     id: "sanjay",
@@ -90,6 +98,8 @@ let USERS_DB: Record<string, UserProfile> = {
     location: "Attibele",
     profile_pic_url: DEFAULT_AVATARS[0],
     isVerified: true,
+    org_code: '0001',
+    management_name: 'Brocode HQ',
   },
   soundar: {
     id: "soundar",
@@ -101,6 +111,8 @@ let USERS_DB: Record<string, UserProfile> = {
     location: "Attibele",
     profile_pic_url: DEFAULT_AVATARS[1],
     isVerified: true,
+    org_code: '0001',
+    management_name: 'Brocode HQ',
   },
   jagadeesh: {
     id: "jagadeesh",
@@ -112,6 +124,8 @@ let USERS_DB: Record<string, UserProfile> = {
     location: "Attibele",
     profile_pic_url: DEFAULT_AVATARS[2],
     isVerified: true,
+    org_code: '0001',
+    management_name: 'Brocode HQ',
   },
   ram: {
     id: "ram",
@@ -123,6 +137,8 @@ let USERS_DB: Record<string, UserProfile> = {
     location: "Attibele",
     profile_pic_url: DEFAULT_AVATARS[3],
     isVerified: true,
+    org_code: '0001',
+    management_name: 'Brocode HQ',
   },
   lingesh: {
     id: "lingesh",
@@ -134,6 +150,8 @@ let USERS_DB: Record<string, UserProfile> = {
     location: "Attibele",
     profile_pic_url: DEFAULT_AVATARS[0],
     isVerified: true,
+    org_code: '0001',
+    management_name: 'Brocode HQ',
   },
 };
 
@@ -297,7 +315,8 @@ export const mockApi = {
 
   async login(
     identifier: string,
-    password: string
+    password: string,
+    orgCode?: string
   ): Promise<{ user: User; profile: UserProfile }> {
     await delay(300);
 
@@ -309,7 +328,8 @@ export const mockApi = {
         (u.email === identifier ||
           u.phone === cleanIdentifier ||
           u.username === identifier) &&
-        u.password === password
+        u.password === password &&
+        (!orgCode?.trim() || u.org_code === orgCode.trim())
     );
 
     if (!profile) throw new Error("Invalid credentials");

--- a/supabase_migration.sql
+++ b/supabase_migration.sql
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS profiles (
   is_verified BOOLEAN DEFAULT false,
   latitude NUMERIC,
   longitude NUMERIC,
+  org_code TEXT,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
@@ -56,6 +57,8 @@ CREATE TABLE IF NOT EXISTS spots (
   feedback TEXT,
   latitude NUMERIC,
   longitude NUMERIC,
+  org_code TEXT,
+  management_name TEXT,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );

--- a/supabase_migration_orgs.sql
+++ b/supabase_migration_orgs.sql
@@ -1,0 +1,36 @@
+-- Multi-management support + org-scoped spots/notifications
+
+-- 1) Add organization fields on profiles
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS org_code TEXT,
+  ADD COLUMN IF NOT EXISTS management_name TEXT;
+
+-- 2) Enforce 4-digit org code format (when provided)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'profiles_org_code_format_check'
+  ) THEN
+    ALTER TABLE profiles
+      ADD CONSTRAINT profiles_org_code_format_check
+      CHECK (org_code IS NULL OR org_code ~ '^[0-9]{4}$');
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS profiles_org_code_idx ON profiles(org_code);
+
+-- 3) Add org code to spots and index it for faster org filtering
+ALTER TABLE spots
+  ADD COLUMN IF NOT EXISTS org_code TEXT;
+
+CREATE INDEX IF NOT EXISTS spots_org_code_idx ON spots(org_code);
+
+-- 4) Backfill existing rows to default org (optional)
+UPDATE profiles
+SET org_code = COALESCE(org_code, '0001'),
+    management_name = COALESCE(management_name, 'Brocode HQ')
+WHERE org_code IS NULL OR management_name IS NULL;
+
+UPDATE spots
+SET org_code = COALESCE(org_code, '0001')
+WHERE org_code IS NULL;

--- a/types.ts
+++ b/types.ts
@@ -35,6 +35,8 @@ export interface UserProfile {
   otpExpiry?: string;
   latitude?: number;
   longitude?: number;
+  org_code?: string;
+  management_name?: string;
 }
 
 export interface Spot {
@@ -50,6 +52,7 @@ export interface Spot {
   latitude?: number;
   longitude?: number;
   members?: UserProfile[];
+  org_code?: string;
 }
 
 export interface Drink {


### PR DESCRIPTION
### Motivation
- Add per-management/org scoping so each admin/management (identified by a 4-digit `Org Code`) only sees and receives notifications for their org, and ensure notification fan-out reliably reaches all users in the org. 
- Capture management metadata during signup so new accounts can be associated with the correct org and admins can manage multiple organizations.

### Description
- Extend types and DB surface: added `org_code` and `management_name` to `UserProfile` and `Spot` in `types.ts` and added a migration `supabase_migration_orgs.sql` to add/index/backfill these columns and enforce a 4-digit org-code format.
- Auth/UI changes: `AuthContext.login` now accepts an optional `orgCode` and Supabase/mock auth are filtered by `profiles.org_code`, and `LoginPage` collects `Org Code` (4 digits) for login and `managementName` + `orgCode` during mobile setup.
- Org-scoped data access: `spotService.getUpcomingSpot/getUpcomingSpots/getPastSpots` accept an optional `orgCode` filter and `createSpot` persists `org_code`, and pages that fetch spots (`HomePage`, `DrinksPage`, `DrinksPageNew`, `PaymentPage`) now pass `profile?.org_code` when calling `getUpcomingSpot`.
- Notification fan-out fix: `notificationService.createNotificationForAllUsers` now accepts an optional `orgCode` and only inserts notifications for users in that org; Home page and real-time handlers pass the current user's org code when broadcasting spot/create/update/delete/RSVP messages.
- Development mock updates: `services/mockApi.ts` updated to include `org_code`/`management_name` on mock users and to respect `orgCode` during mock login; `profileService.createProfile` persists org metadata.

### Testing
- Ran `npm run build` successfully (production build completed without errors). 
- Started the dev server (`vite`) and verified the updated login UI (Org Code field) by capturing a screenshot of the running app (screenshot produced). 
- Verified the app compiles after iterative edits (second `npm run build` also succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b09250120832ebf52bc9102911f0d)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/fuzziecoder/brocode-party-update-app/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
