### PR TITLE
fix: enforce catalog integrity for order item creation

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -242,7 +242,21 @@ export const database = {
 
   createOrder({ spotId, userId, items }) {
     const parsedItems = items.map((item) => {
-      if ('name' in item || 'unitPrice' in item || 'total' in item) {
+      if (
+        !item || 
+        typeof item!== 'object' || 
+        Array.isArray(item)
+      ) 
+      {
+        throw new Error('Invalid item format');
+      }
+      if(
+        //if item has it's own property
+        Object.prototype.hasOwnProperty.call(item, 'name') ||
+        Object.prototype.hasOwnProperty.call(item, 'unitPrice') ||
+        Object.prototype.hasOwnProperty.call(item, 'total')
+      )
+      {
       throw new Error('Do not provide name, unitPrice, or total. These are derived from catalog. ')
       }
       const quantity = Number(item.quantity || 0);

--- a/backend/db.js
+++ b/backend/db.js
@@ -242,6 +242,9 @@ export const database = {
 
   createOrder({ spotId, userId, items }) {
     const parsedItems = items.map((item) => {
+      if ('name' in item || 'unitPrice' in item || 'total' in item) {
+      throw new Error('Do not provide name, unitPrice, or total. These are derived from catalog. ')
+      }
       const quantity = Number(item.quantity || 0);
       if (!item.productId || !Number.isInteger(quantity) || quantity <= 0) {
         throw new Error('Each order item must include productId and a positive integer quantity');


### PR DESCRIPTION
Fixes #18 

Changes:

- computes total server-side
- prevents client from overriding financial values
- rejects unknown products

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Order submissions now reject items that are not plain objects and disallow supplying name, unitPrice, or total on items, improving order data integrity and preventing malformed orders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->